### PR TITLE
feat:support process consumerSendMsgBack as throw exception,

### DIFF
--- a/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/RocketMQServiceConfiguration.java
+++ b/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/RocketMQServiceConfiguration.java
@@ -504,4 +504,12 @@ public class RocketMQServiceConfiguration extends ServiceConfiguration {
             doc = "RoP name check enable.\n"
     )
     private boolean ropNameCheckEnable = true;
+
+
+    @FieldContext(
+            category = CATEGORY_ROCKETMQ,
+            doc = "process consumerSendMsgBack as throw exception.\n"
+    )
+    private boolean quickTerminateConsumeBack = false;
+
 }

--- a/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/processor/SendMessageProcessor.java
+++ b/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/processor/SendMessageProcessor.java
@@ -138,7 +138,7 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
         if (this.brokerController.getServerConfig().isQuickTerminateConsumeBack()) {
             response.setCode(ResponseCode.SYSTEM_ERROR);
-            response.setRemark("consumerSendMsgBack process failed,will retry later " +request.getRemark());
+            response.setRemark("consumerSendMsgBack process failed,will retry later " + request.getRemark());
             return response;
         }
         final ConsumerSendMsgBackRequestHeader requestHeader =
@@ -411,7 +411,7 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
                     traceContext.setPersistStartTime(System.currentTimeMillis());
                 }
                 this.getServerCnxMsgStore(ctx,
-                        CommonUtils.getInnerProducerGroupName(request, requestHeader.getProducerGroup()))
+                                CommonUtils.getInnerProducerGroupName(request, requestHeader.getProducerGroup()))
                         .putMessage(CommonUtils.getPulsarPartitionIdByRequest(request),
                                 msgInner,
                                 requestHeader.getProducerGroup(),
@@ -601,7 +601,7 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
                 traceContext.setPersistStartTime(System.currentTimeMillis());
             }
             this.getServerCnxMsgStore(ctx,
-                    CommonUtils.getInnerProducerGroupName(request, requestHeader.getProducerGroup()))
+                            CommonUtils.getInnerProducerGroupName(request, requestHeader.getProducerGroup()))
                     .putMessages(CommonUtils.getPulsarPartitionIdByRequest(request),
                             messageExtBatch,
                             requestHeader.getProducerGroup(),

--- a/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/processor/SendMessageProcessor.java
+++ b/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/processor/SendMessageProcessor.java
@@ -136,17 +136,14 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
     private RemotingCommand consumerSendMsgBack(final ChannelHandlerContext ctx, final RemotingCommand request)
             throws RemotingCommandException {
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
+        if (this.brokerController.getServerConfig().isQuickTerminateConsumeBack()) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("consumerSendMsgBack process failed,will retry later " +request.getRemark());
+            return response;
+        }
         final ConsumerSendMsgBackRequestHeader requestHeader =
                 (ConsumerSendMsgBackRequestHeader) request
                         .decodeCommandCustomHeader(ConsumerSendMsgBackRequestHeader.class);
-
-        if (this.brokerController.getServerConfig().isQuickTerminateConsumeBack()) {
-            response.setCode(ResponseCode.SYSTEM_ERROR);
-            response.setRemark("consumerSendMsgBack process failed,will retry later " +requestHeader.getOriginTopic()+","+ requestHeader.getOffset());
-            return response;
-        }
-
-
         String namespace = NamespaceUtil.getNamespaceFromResource(requestHeader.getGroup());
         if (this.hasConsumeMessageHook() && !UtilAll.isBlank(requestHeader.getOriginMsgId())) {
             ConsumeMessageContext context = new ConsumeMessageContext();

--- a/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/processor/SendMessageProcessor.java
+++ b/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/processor/SendMessageProcessor.java
@@ -139,6 +139,14 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
         final ConsumerSendMsgBackRequestHeader requestHeader =
                 (ConsumerSendMsgBackRequestHeader) request
                         .decodeCommandCustomHeader(ConsumerSendMsgBackRequestHeader.class);
+
+        if (this.brokerController.getServerConfig().isQuickTerminateConsumeBack()) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("consumerSendMsgBack process failed,will retry later " +requestHeader.getOriginTopic()+","+ requestHeader.getOffset());
+            return response;
+        }
+
+
         String namespace = NamespaceUtil.getNamespaceFromResource(requestHeader.getGroup());
         if (this.hasConsumeMessageHook() && !UtilAll.isBlank(requestHeader.getOriginMsgId())) {
             ConsumeMessageContext context = new ConsumeMessageContext();


### PR DESCRIPTION
consumerSendMsgBack will read from pulsar now, it will be slow in some scene

we can allow users to throw exception,then rocketmq will resend the message as a normal message.