### PR TITLE
增加TLS支持

### DIFF
--- a/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/NettyRemotingAbstract.java
+++ b/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/NettyRemotingAbstract.java
@@ -32,6 +32,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.acl.common.AclException;
 import org.apache.rocketmq.remoting.ChannelEventListener;
@@ -90,6 +93,12 @@ public abstract class NettyRemotingAbstract {
      * The default request processor to use in case there is no exact match in {@link #processorTable} per request code.
      */
     protected Pair<NettyRequestProcessor, ExecutorService> defaultRequestProcessor;
+
+    /**
+     * SSL context via which to create {@link SslHandler}.
+     */
+    protected volatile SslContext sslContext;
+
     /**
      * custom rpc hooks.
      */

--- a/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/proxy/RopBrokerProxy.java
+++ b/rocketmq-impl/src/main/java/org/streamnative/pulsar/handlers/rocketmq/inner/proxy/RopBrokerProxy.java
@@ -73,6 +73,8 @@ import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
+import org.apache.pulsar.zookeeper.ZookeeperBkClientFactoryImpl;
 import org.apache.rocketmq.broker.mqtrace.ConsumeMessageHook;
 import org.apache.rocketmq.broker.mqtrace.SendMessageHook;
 import org.apache.rocketmq.client.exception.MQBrokerException;
@@ -781,7 +783,11 @@ public class RopBrokerProxy extends RocketMQRemoteServer implements AutoCloseabl
         try {
             this.pulsarService = brokerController.getBrokerService().pulsar();
             ServiceConfiguration config = this.pulsarService.getConfig();
-            RopZookeeperCache ropZkCache = new RopZookeeperCache(pulsarService.getZkClientFactory(),
+            ZooKeeperClientFactory zkClientFactory = pulsarService.getZkClientFactory();
+            if (zkClientFactory == null) {
+                zkClientFactory = new ZookeeperBkClientFactoryImpl(pulsarService.getOrderedExecutor());
+            }
+            RopZookeeperCache ropZkCache = new RopZookeeperCache(zkClientFactory,
                     (int) config.getZooKeeperSessionTimeoutMillis(),
                     config.getZooKeeperOperationTimeoutSeconds(), config.getZookeeperServers(), orderedExecutor,
                     brokerController.getScheduledExecutorService(), config.getZooKeeperCacheExpirySeconds());


### PR DESCRIPTION
参照RocketMQ的实现，在握手时发现客户端试图建立TLS连接，在netty的pipeline中增加SslHandler，处理TLS的请求和响应。